### PR TITLE
Add Support for Atlas Chatbot

### DIFF
--- a/atila/settings.py
+++ b/atila/settings.py
@@ -41,7 +41,7 @@ CORS_ORIGIN_WHITELIST = (
 ALLOWED_HOSTS = ['atila-core-service.herokuapp.com', 'atila-core-service-299c222291ba.herokuapp.com']
 
 if DEBUG:
-    ALLOWED_HOSTS += ['localhost', '127.0.0.1', '0.0.0.0']
+    ALLOWED_HOSTS += ['localhost', '127.0.0.1', '0.0.0.0', 'host.docker.internal']
     CORS_ORIGIN_WHITELIST += (
         'http://127.0.0.1:3000',
         'http://localhost:3000',)

--- a/atlas/utils.py
+++ b/atlas/utils.py
@@ -72,8 +72,17 @@ def send_ai_request(request_args: dict, provider="huggingface"):
 
     request_body = json.dumps(request_body)
     response = requests.post(url, data=request_body, headers=headers)
-    response.raise_for_status()
-    if 'error' in response.json():
-        raise HTTPError(response.json())
+
+    try:
+        response.raise_for_status()  # Raise an exception for 4xx/5xx errors
+        response_data = response.json()
+
+        if 'error' in response_data:
+            print("Error in response:", response_data)  # Print the error before raising
+            raise HTTPError(response_data)  # Raise the error with the response data
+
+    except HTTPError as err:
+        print(f"HTTPError occurred: {err}")  # You can log or print the error here if needed
+        raise  # Re-raise the exception if needed to propagate further
 
     return response.json()

--- a/start.sh
+++ b/start.sh
@@ -1,2 +1,6 @@
+# Define the port
+# Use 8001 to avoid clashing with atila-django which sometimes runs at same time as atila-django in dev
+PORT=8001
+
 source .env
-python manage.py runserver
+python manage.py runserver $PORT


### PR DESCRIPTION
See: https://github.com/ademidun/atila-django/pull/450

### Summary:
- **`atila/settings.py`**: Added `'host.docker.internal'` to `ALLOWED_HOSTS` in the development environment (`DEBUG=True`) to accommodate Docker for local development.
- **`atlas/transcribe.py`**:
  - Refactored the `transcribe_and_search_video` function to add a `use_ai` parameter, allowing users to choose between AI transcription or Whisper transcription.
  - Enhanced error handling with better error messages when failing to retrieve YouTube transcripts.
  - Skipped redundant transcription and embedding if the video already exists in the database or Pinecone.
  - Improved logging for transcription and search operations.
- **`atlas/utils.py`**: Improved error handling when sending AI requests by catching HTTP errors and logging the response error.
- **`start.sh`**: Introduced a `PORT` variable to use port 8001 to avoid conflicts with other services running on port 8000 (e.g. [atila-django](https://github.com/ademidun/atila-django/pull/450)) during development.
